### PR TITLE
Feat (vault): Merge two vaults.

### DIFF
--- a/app/src/main/java/org/vault/VaultManager.java
+++ b/app/src/main/java/org/vault/VaultManager.java
@@ -37,7 +37,8 @@ public class VaultManager implements AutoCloseable {
           "  url TEXT NOT NULL," +
           "  username TEXT NOT NULL," +
           "  password TEXT NOT NULL," +
-          "  iv TEXT NOT NULL" +
+          "  iv TEXT NOT NULL," +
+          "  timestamp INTEGER NOT NULL" +
           ");");
       statement.executeUpdate("DELETE FROM metadata;");
 
@@ -159,11 +160,12 @@ public class VaultManager implements AutoCloseable {
     String ivB64 = encrypted.getIV();
 
     try (PreparedStatement preparedStatement = this.connection
-        .prepareStatement("INSERT INTO entries(url, username, password, iv) VALUES(?,?,?,?)")) {
+        .prepareStatement("INSERT INTO entries(url, username, password, iv, timestamp) VALUES(?,?,?,?,?)")) {
       preparedStatement.setString(1, urlField);
       preparedStatement.setString(2, usernameField);
       preparedStatement.setString(3, cipherB64);
       preparedStatement.setString(4, ivB64);
+      preparedStatement.setLong(5, System.currentTimeMillis());
 
       preparedStatement.executeUpdate();
       this.connection.commit();
@@ -250,14 +252,15 @@ public class VaultManager implements AutoCloseable {
 
     try (PreparedStatement ps = connection.prepareStatement(
         "UPDATE entries " +
-            "SET url = ?, username = ?, password = ?, iv = ? " +
+            "SET url = ?, username = ?, password = ?, iv = ?, timestamp = ? " +
             "WHERE id = ?")) {
 
       ps.setString(1, newUrl);
       ps.setString(2, newUsername);
       ps.setString(3, cipherB64);
       ps.setString(4, ivB64);
-      ps.setInt(5, entryID);
+      ps.setLong(5, System.currentTimeMillis());
+      ps.setInt(6, entryID);
 
       int affected = ps.executeUpdate();
       if (affected == 0) {
@@ -311,6 +314,107 @@ public class VaultManager implements AutoCloseable {
     }
 
     return Base64.getDecoder().decode(saltB64);
+  }
+
+  public VaultStatus merge(VaultManager other) throws IllegalStateException {
+    if (!this.masterPasswd.equals(other.masterPasswd)) {
+      throw new IllegalArgumentException(
+          "[VaultManager.merge] ERROR: Cannot two vaults with different master password.");
+    }
+    if (this.connection == null) {
+      if (this.connectToDB() != VaultStatus.DBConnectionSuccess) {
+        throw new IllegalStateException("[VaultManager.merge] ERROR: Cannot open this vault.");
+      }
+    }
+    if (other.connection == null) {
+      if (other.connectToDB() != VaultStatus.DBConnectionSuccess) {
+        throw new IllegalStateException("[VaultManager.merge] ERROR: Cannot open the other vault.");
+      }
+    }
+
+    byte[] salt, otherSalt;
+    try {
+      salt = this.verifyMasterPasswd(this.masterPasswd);
+      otherSalt = other.verifyMasterPasswd(other.masterPasswd);
+
+      if (salt == null || otherSalt == null) {
+        return VaultStatus.DBMergeFailureException;
+      }
+    } catch (IllegalStateException e) {
+      System.out.println("[VaultManager.editEntry] ERROR: ");
+      e.printStackTrace();
+      return VaultStatus.DBBadVerificationFormat;
+    } catch (SecurityException e) {
+      System.out.println("[VaultManager.editEntry] ERROR: ");
+      e.printStackTrace();
+      return VaultStatus.DBWrongMasterPasswd;
+    } catch (Exception e) {
+      System.out.println("[VaultManager.editEnty] ERROR: ");
+      e.printStackTrace();
+      return VaultStatus.DBMergeFailureException;
+    }
+
+    try (
+        PreparedStatement psOther = other.connection
+            .prepareStatement("SELECT id, url, username, password, iv, timestamp FROM entries");
+        ResultSet rsOther = psOther.executeQuery()) {
+      String lookup = "SELECT timestamp FROM entries WHERE id = ?";
+      String insert = "INSERT INTO entries(id, url, username, password, iv, timestamp) VALUES(?,?,?,?,?,?)";
+      String updateSql = "UPDATE entries " +
+          "SET url       = ?, " +
+          " username  = ?, " +
+          " password  = ?, " +
+          " iv        = ?, " +
+          " timestamp = ? " +
+          " WHERE id = ?";
+
+      try (PreparedStatement psLookup = this.connection.prepareStatement(lookup);
+          PreparedStatement psInsert = this.connection.prepareStatement(insert);
+          PreparedStatement psUpdate = this.connection.prepareStatement(updateSql)) {
+        while (rsOther.next()) {
+          int otherId = rsOther.getInt("id");
+          String otherUrl = rsOther.getString("url");
+          String otherUsername = rsOther.getString("username");
+          String otherCipher = rsOther.getString("password");
+          String otherIv = rsOther.getString("iv");
+          long otherTimestamp = rsOther.getLong("timestamp");
+
+          psLookup.setInt(1, otherId);
+          try (ResultSet rsSelf = psLookup.executeQuery()) {
+            if (rsSelf.next()) {
+              long selfTimestamp = rsSelf.getLong("timestamp");
+
+              if (otherTimestamp > selfTimestamp) {
+                psUpdate.setString(1, otherUrl);
+                psUpdate.setString(2, otherUsername);
+                psUpdate.setString(3, otherCipher);
+                psUpdate.setString(4, otherIv);
+                psUpdate.setLong(5, otherTimestamp);
+                psUpdate.setInt(6, otherId);
+
+                psUpdate.executeUpdate();
+              }
+            } else {
+              psInsert.setInt(1, otherId);
+              psInsert.setString(2, otherUrl);
+              psInsert.setString(3, otherUsername);
+              psInsert.setString(4, otherCipher);
+              psInsert.setString(5, otherIv);
+              psInsert.setLong(6, otherTimestamp);
+
+              psInsert.executeUpdate();
+            }
+          }
+        }
+      }
+
+      this.connection.commit();
+      return VaultStatus.DBMergeSuccess;
+    } catch (SQLException e) {
+      System.out.println("[VaultManager.merge] ERROR: ");
+      e.printStackTrace();
+      return VaultStatus.DBMergeFailureException;
+    }
   }
 
   public VaultStatus connectToDB() {

--- a/app/src/main/java/org/vault/VaultManager.java
+++ b/app/src/main/java/org/vault/VaultManager.java
@@ -327,7 +327,7 @@ public class VaultManager implements AutoCloseable {
     }
     if (other.connection == null) {
       if (other.connectToDB() != VaultStatus.DBConnectionSuccess) {
-        return VaultStatus.DBOtherConnectionFailure;
+        return VaultStatus.DBParameterVaultConnectionFailure;
       }
     }
 

--- a/app/src/main/java/org/vault/VaultStatus.java
+++ b/app/src/main/java/org/vault/VaultStatus.java
@@ -28,6 +28,7 @@ public enum VaultStatus {
 
   DBMergeSuccess,
   DBMergeFailureException,
+  DBMergeDifferentMasterPasswd,
 
   DBCloseSuccess,
   DBCloseFailure

--- a/app/src/main/java/org/vault/VaultStatus.java
+++ b/app/src/main/java/org/vault/VaultStatus.java
@@ -3,7 +3,7 @@ package org.vault;
 public enum VaultStatus {
   DBConnectionSuccess,
   DBConnectionFailure,
-  DBOtherConnectionFailure,
+  DBParameterVaultConnectionFailure,
 
   DBCreateVaultSuccess,
   DBCreateVaultFailure,

--- a/app/src/main/java/org/vault/VaultStatus.java
+++ b/app/src/main/java/org/vault/VaultStatus.java
@@ -26,6 +26,9 @@ public enum VaultStatus {
   DBBadVerificationFormat,
   DBWrongMasterPasswd,
 
+  DBMergeSuccess,
+  DBMergeFailureException,
+
   DBCloseSuccess,
   DBCloseFailure
 }

--- a/app/src/main/java/org/vault/VaultStatus.java
+++ b/app/src/main/java/org/vault/VaultStatus.java
@@ -3,6 +3,7 @@ package org.vault;
 public enum VaultStatus {
   DBConnectionSuccess,
   DBConnectionFailure,
+  DBOtherConnectionFailure,
 
   DBCreateVaultSuccess,
   DBCreateVaultFailure,

--- a/app/src/test/java/org/vault/VaultManagerTest.java
+++ b/app/src/test/java/org/vault/VaultManagerTest.java
@@ -169,10 +169,8 @@ class VaultManagerTest {
 
     boolean foundA = merged.stream()
         .anyMatch(e -> e.getURL().equals("urlB") && e.getUsername().equals("userB") && e.getPasswd().equals("passB"));
-    boolean foundB = merged.stream()
-        .anyMatch(e -> e.getURL().equals("urlB") && e.getUsername().equals("userB") && e.getPasswd().equals("passB"));
 
-    assertTrue(foundA && foundB, "Both vault entries only have the latest values after merge.");
+    assertTrue(foundA, "Merged vault should only have the latest.");
 
     assertEquals(VaultStatus.DBCloseSuccess, v2.closeDB());
   }
@@ -199,12 +197,16 @@ class VaultManagerTest {
 
     Entry e = merged.get(0);
     Entry e1 = merged.get(1);
+    Entry e2 = merged.get(2);
     assertEquals("site-new", e.getURL());
     assertEquals("alice-new", e.getUsername());
     assertEquals("newPass", e.getPasswd());
     assertEquals("site1", e1.getURL());
     assertEquals("alice1", e1.getUsername());
     assertEquals("changedPass1", e1.getPasswd());
+    assertEquals("site2", e2.getURL());
+    assertEquals("alice2", e2.getUsername());
+    assertEquals("oldPass2", e2.getPasswd());
 
     assertEquals(VaultStatus.DBCloseSuccess, v2.closeDB());
   }

--- a/app/src/test/java/org/vault/VaultManagerTest.java
+++ b/app/src/test/java/org/vault/VaultManagerTest.java
@@ -217,7 +217,7 @@ class VaultManagerTest {
     assertEquals(VaultStatus.DBConnectionSuccess, v2.connectToDB());
     assertEquals(VaultStatus.DBCreateVaultSuccess, v2.createVault());
 
-    assertThrows(IllegalArgumentException.class, () -> vm.merge(v2));
+    assertEquals(VaultStatus.DBMergeDifferentMasterPasswd, vm.merge(v2));
 
     assertEquals(VaultStatus.DBCloseSuccess, v2.closeDB());
   }

--- a/app/src/test/java/org/vault/VaultManagerTest.java
+++ b/app/src/test/java/org/vault/VaultManagerTest.java
@@ -185,19 +185,26 @@ class VaultManagerTest {
     assertEquals(VaultStatus.DBCreateVaultSuccess, v2.createVault());
 
     assertEquals(VaultStatus.DBAddEntrySuccess, vm.addEntry("site", "alice", "oldPass"));
+    assertEquals(VaultStatus.DBAddEntrySuccess, vm.addEntry("site1", "alice1", "oldPass1"));
+    assertEquals(VaultStatus.DBAddEntrySuccess, vm.addEntry("site2", "alice2", "oldPass2"));
     Thread.sleep(10);
     assertEquals(VaultStatus.DBAddEntrySuccess, v2.addEntry("site-new", "alice-new", "newPass"));
+    assertEquals(VaultStatus.DBAddEntrySuccess, v2.addEntry("site1", "alice1", "changedPass1"));
 
     assertEquals(VaultStatus.DBMergeSuccess, vm.merge(v2));
 
     ArrayList<Entry> merged = new ArrayList<>();
     assertEquals(VaultStatus.DBOpenVaultSuccess, vm.openVault(merged));
-    assertEquals(1, merged.size());
+    assertEquals(3, merged.size());
 
     Entry e = merged.get(0);
+    Entry e1 = merged.get(1);
     assertEquals("site-new", e.getURL());
     assertEquals("alice-new", e.getUsername());
     assertEquals("newPass", e.getPasswd());
+    assertEquals("site1", e1.getURL());
+    assertEquals("alice1", e1.getUsername());
+    assertEquals("changedPass1", e1.getPasswd());
 
     assertEquals(VaultStatus.DBCloseSuccess, v2.closeDB());
   }


### PR DESCRIPTION
Usage:

Merging v2 *into* v1 when both are of type `VaultManager`,

```java
v1.merge(v2);
```

In this example, only `v1` is subject to change. Each entry of the table `entries` changes if and only if the timestamp of an entry in `v2` is greater than that of the entry of `v1` with the same id.