### PR TITLE
feat(tools): Print a summary of tests after running them

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,22 @@ tasks.named<Test>("test") {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
     testLogging {
+      events("failed", "skipped")
       showStandardStreams = true
     }
+}
+
+tasks.withType<AbstractTestTask> {
+    afterSuite(
+        KotlinClosure2({ desc: TestDescriptor, result: TestResult ->
+            // Only execute on the outermost suite
+            if (desc.parent == null) {
+                println("\n **** Result: ${result.resultType} ****")
+                println("  >    Tests: ${result.testCount}")
+                println("  >   Passed: ${result.successfulTestCount}")
+                println("  >   Failed: ${result.failedTestCount}")
+                println("  >  Skipped: ${result.skippedTestCount}")
+            }
+        })
+    )
 }


### PR DESCRIPTION
Prints a summary like so:

![image](https://github.com/user-attachments/assets/bcbe4d55-0701-4e3f-a15f-67d55d17a51f)

This makes it easier to keep track of the test statuses. 