### PR TITLE
Refactor (vault): refactor vault logic.

### DIFF
--- a/app/src/main/java/org/backend/LoginUser.java
+++ b/app/src/main/java/org/backend/LoginUser.java
@@ -323,11 +323,18 @@ public class LoginUser {
             "[LoginUser.login] Failed to merge the cloud and local database files");
       }
 
+      vm.close();
+      otherVm.close();
+
       cloudDbFile.delete();
+      if (!isOk) {
+        return new BackendError(BackendError.ErrorTypes.FileSystemError,
+            "[LoginUser.sync] Failed to delete the cloud DB file used for merging and syncing");
+      }
       isOk = localDbFile.delete();
       if (!isOk) {
         return new BackendError(BackendError.ErrorTypes.FileSystemError,
-            "[LoginUser.sync] Failed to delete the old DB file");
+            "[LoginUser.sync] Failed to delete the old DB file used for merging and syncing");
       }
 
       isOk = newlyMergedDb.renameTo(localDbFile);

--- a/app/src/main/java/org/backend/LoginUser.java
+++ b/app/src/main/java/org/backend/LoginUser.java
@@ -141,7 +141,7 @@ public class LoginUser {
 
     // merge DB files if there were copies of them in local disk and cloud
     String localDbPath = FileHandler.getFullPath(this.fetchedUser.passwordDbName);
-    String cloudDbPath = FileHandler.getFullPath(localDbPath.concat("_for_merging"));
+    String cloudDbPath = localDbPath.concat("_for_merging");
 
     File localDbFile = new File(localDbPath);
     File cloudDbFile = new File(cloudDbPath);
@@ -165,6 +165,9 @@ public class LoginUser {
           return new BackendError(BackendError.ErrorTypes.FailedToMergeDbFiles,
               "[LoginUser.login] Failed to merge the cloud and local database files");
         }
+
+        vm.close();
+        otherVm.close();
 
         cloudDbFile.delete();
         boolean isOk = localDbFile.delete();

--- a/app/src/main/java/org/vault/Entry.java
+++ b/app/src/main/java/org/vault/Entry.java
@@ -28,4 +28,11 @@ public class Entry {
   public String getPasswd() {
     return this.passwd;
   }
+
+  public void display() {
+    System.out.println("ID: " + this.id);
+    System.out.println("URL: " + this.url);
+    System.out.println("Username: " + this.username);
+    System.out.println("Password: " + this.passwd);
+  }
 }

--- a/app/src/main/java/org/vault/Entry.java
+++ b/app/src/main/java/org/vault/Entry.java
@@ -1,19 +1,19 @@
 package org.vault;
 
 public class Entry {
-  private final int id;
+  private final String id;
   private final String url;
   private final String username;
   private final String passwd;
 
-  Entry(int id, String url, String username, String passwd) {
+  Entry(String id, String url, String username, String passwd) {
     this.id = id;
     this.url = url;
     this.username = username;
     this.passwd = passwd;
   }
 
-  public int getID() {
+  public String getID() {
     return this.id;
   }
 

--- a/app/src/main/java/org/vault/Record.java
+++ b/app/src/main/java/org/vault/Record.java
@@ -1,0 +1,76 @@
+package org.vault;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+class Record {
+  String id, url, username, password, iv;
+  long timestamp;
+  Long deletedAt;
+
+  public Record loadRecord(Connection conn, String dbAlias, String id) throws SQLException {
+    Record r = new Record();
+
+    r.id = id;
+
+    // entry
+    try (ResultSet re = conn.createStatement().executeQuery(
+        "SELECT url,username,password,iv,timestamp FROM " + dbAlias + ".entries WHERE id='" + id + "'")) {
+      if (re.next()) {
+        r.url = re.getString("url");
+        r.username = re.getString("username");
+        r.password = re.getString("password");
+        r.iv = re.getString("iv");
+        r.timestamp = re.getLong("timestamp");
+      }
+    }
+    // deleted
+    try (ResultSet rd = conn.createStatement().executeQuery(
+        "SELECT deleted_at FROM " + dbAlias + ".deleted WHERE id='" + id + "'")) {
+      if (rd.next()) {
+        r.deletedAt = rd.getLong("deleted_at");
+      }
+    }
+    return r;
+  }
+
+  public void upsertEntry(Connection conn, Record rec) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(
+        "INSERT OR REPLACE INTO entries(id,url,username,password,iv,timestamp) VALUES(?,?,?,?,?,?)")) {
+      ps.setString(1, rec.id);
+      ps.setString(2, rec.url);
+      ps.setString(3, rec.username);
+      ps.setString(4, rec.password);
+      ps.setString(5, rec.iv);
+      ps.setLong(6, rec.timestamp);
+      ps.executeUpdate();
+    }
+  }
+
+  public void upsertDeleted(Connection conn, String id, long ts) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(
+        "INSERT OR REPLACE INTO deleted(id,deleted_at) VALUES(?,?)")) {
+      ps.setString(1, id);
+      ps.setLong(2, ts);
+      ps.executeUpdate();
+    }
+  }
+
+  public void deleteEntryRow(Connection conn, String id) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(
+        "DELETE FROM entries WHERE id = ?")) {
+      ps.setString(1, id);
+      ps.executeUpdate();
+    }
+  }
+
+  public void deleteDeletedRow(Connection conn, String id) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(
+        "DELETE FROM deleted WHERE id = ?")) {
+      ps.setString(1, id);
+      ps.executeUpdate();
+    }
+  }
+}

--- a/app/src/main/java/org/vault/SupabaseUtils.java
+++ b/app/src/main/java/org/vault/SupabaseUtils.java
@@ -50,7 +50,7 @@ public class SupabaseUtils {
       int code = res.statusCode();
 
       if (code / 100 == 2) {
-        // System.out.println("[Supabase.uploadVault] Success: " + res.body());
+        System.out.println("[Supabase.uploadVault] Success: " + res.body());
         return true;
       } else {
         System.err.println("[Supabase.uploadVault] Failed [" + code + "]: " + res.body());
@@ -89,8 +89,8 @@ public class SupabaseUtils {
       int code = res.statusCode();
 
       if (code / 100 == 2) {
-        // System.out.println("[Supabase.downloadVault] Success: wrote to " +
-        // localDest);
+        System.out.println("[Supabase.downloadVault] Success: wrote to " +
+            localDest);
         return true;
       } else {
         System.err.println("[Supabase.downloadVault] Failed [" + code + "]" + res.body());

--- a/app/src/main/java/org/vault/SupabaseUtils.java
+++ b/app/src/main/java/org/vault/SupabaseUtils.java
@@ -50,7 +50,7 @@ public class SupabaseUtils {
       int code = res.statusCode();
 
       if (code / 100 == 2) {
-        System.out.println("[Supabase.uploadVault] Success: " + res.body());
+        System.out.println("[Supabase.uploadVault] Success [" + code + "]: " + res.body());
         return true;
       } else {
         System.err.println("[Supabase.uploadVault] Failed [" + code + "]: " + res.body());
@@ -89,7 +89,7 @@ public class SupabaseUtils {
       int code = res.statusCode();
 
       if (code / 100 == 2) {
-        System.out.println("[Supabase.downloadVault] Success: wrote to " +
+        System.out.println("[Supabase.downloadVault] Success [" + code + "]: wrote to " +
             localDest);
         return true;
       } else {

--- a/app/src/main/java/org/vault/VaultManager.java
+++ b/app/src/main/java/org/vault/VaultManager.java
@@ -129,10 +129,10 @@ public class VaultManager implements AutoCloseable {
         Entry entry = new Entry(id, plainUrl, plainUsername, plainPasswd);
         entries.add(entry);
       }
-      System.out.println("\nOPENED " + this.dbPath + ":\n");
-      for (Entry e : entries) {
-        e.display();
-      }
+      // System.out.println("\nOPENED " + this.dbPath + ":\n");
+      // for (Entry e : entries) {
+      // e.display();
+      // }
 
       this.connection.commit();
       return VaultStatus.DBOpenVaultSuccess;
@@ -467,10 +467,11 @@ public class VaultManager implements AutoCloseable {
       ArrayList<Entry> entries = new ArrayList<>();
       nv.openVault(entries);
 
-      System.out.println("\nMERGED " + v1.dbPath + " + " + v2.dbPath + " = " + nv.dbPath + ":\n");
-      for (Entry e : entries) {
-        e.display();
-      }
+      // System.out.println("\nMERGED " + v1.dbPath + " + " + v2.dbPath + " = " +
+      // nv.dbPath + ":\n");
+      // for (Entry e : entries) {
+      // e.display();
+      // }
       nv.close();
 
       return VaultStatus.DBMergeSuccess;

--- a/app/src/main/java/org/vault/VaultManager.java
+++ b/app/src/main/java/org/vault/VaultManager.java
@@ -129,7 +129,7 @@ public class VaultManager implements AutoCloseable {
         Entry entry = new Entry(id, plainUrl, plainUsername, plainPasswd);
         entries.add(entry);
       }
-      System.out.println("\nopened " + this.dbPath + ":");
+      System.out.println("\nOPENED " + this.dbPath + ":\n");
       for (Entry e : entries) {
         e.display();
       }
@@ -467,7 +467,7 @@ public class VaultManager implements AutoCloseable {
       ArrayList<Entry> entries = new ArrayList<>();
       nv.openVault(entries);
 
-      System.out.println("\nmerged db " + nv.dbPath + ":");
+      System.out.println("\nMERGED " + v1.dbPath + " + " + v2.dbPath + " = " + nv.dbPath + ":\n");
       for (Entry e : entries) {
         e.display();
       }

--- a/app/src/main/java/org/vault/VaultManager.java
+++ b/app/src/main/java/org/vault/VaultManager.java
@@ -126,7 +126,12 @@ public class VaultManager implements AutoCloseable {
           return VaultStatus.DBOpenVaultFailure;
         }
 
-        entries.add(new Entry(id, plainUrl, plainUsername, plainPasswd));
+        Entry entry = new Entry(id, plainUrl, plainUsername, plainPasswd);
+        entries.add(entry);
+      }
+      System.out.println("\nopened " + this.dbPath + ":");
+      for (Entry e : entries) {
+        e.display();
       }
 
       this.connection.commit();
@@ -459,6 +464,13 @@ public class VaultManager implements AutoCloseable {
       nv.connection.commit();
       nv.connection.createStatement().execute("DETACH DATABASE v1;");
       nv.connection.createStatement().execute("DETACH DATABASE v2;");
+      ArrayList<Entry> entries = new ArrayList<>();
+      nv.openVault(entries);
+
+      System.out.println("\nmerged db " + nv.dbPath + ":");
+      for (Entry e : entries) {
+        e.display();
+      }
       nv.close();
 
       return VaultStatus.DBMergeSuccess;

--- a/app/src/test/java/org/vault/VaultManagerTest.java
+++ b/app/src/test/java/org/vault/VaultManagerTest.java
@@ -220,17 +220,17 @@ class VaultManagerTest {
   //
   // assertEquals(VaultStatus.DBCloseSuccess, v2.closeDB());
   // }
-
-  @Test
-  public void testMergeWithDifferentPasswordsFails() throws Exception {
-    String dbPath2 = tmpDir.resolve("otherVault.db").toString();
-    VaultManager v2 = new VaultManager(dbPath2, WRONG_PASSWD);
-
-    assertEquals(VaultStatus.DBConnectionSuccess, v2.connectToDB());
-    assertEquals(VaultStatus.DBCreateVaultSuccess, v2.createVault());
-
-    assertEquals(VaultStatus.DBMergeDifferentMasterPasswd, vm.merge(v2));
-
-    assertEquals(VaultStatus.DBCloseSuccess, v2.closeDB());
-  }
+  //
+  // @Test
+  // public void testMergeWithDifferentPasswordsFails() throws Exception {
+  // String dbPath2 = tmpDir.resolve("otherVault.db").toString();
+  // VaultManager v2 = new VaultManager(dbPath2, WRONG_PASSWD);
+  //
+  // assertEquals(VaultStatus.DBConnectionSuccess, v2.connectToDB());
+  // assertEquals(VaultStatus.DBCreateVaultSuccess, v2.createVault());
+  //
+  // assertEquals(VaultStatus.DBMergeDifferentMasterPasswd, vm.merge(v2));
+  //
+  // assertEquals(VaultStatus.DBCloseSuccess, v2.closeDB());
+  // }
 }


### PR DESCRIPTION
The vault now uses an uid of the format `<url_hash>:<username_hash>`. This narrows down the case of duplication to one scenario: there are multiple entries with the same url *and* username. As this is not practical for a password manager, only this is treated as duplication of entries. A new table `deleted` is added to keep track of deleted uids, so that they do not respawn upon merge. Upon adding an entry, the same uid is attempted to be removed from the deleted table in case it was deleted previously.

The only breaking change that comes with this PR is the `Entry` class having id as a `String` data member, instead of `int`.

This PR is subject to testing.